### PR TITLE
Use custom build of baresip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,13 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /rootfs
 
-# FROM base AS pulseaudio
-# ARG DEBIAN_FRONTEND
+FROM base AS baresip
+ARG DEBIAN_FRONTEND
 
-# # bind /var/cache/apt to tmpfs to speed up pulseaudio build
-# RUN --mount=type=tmpfs,target=/tmp --mount=type=tmpfs,target=/var/cache/apt \
-#     --mount=type=bind,source=docker/build_pulseaudio.sh,target=/deps/build_pulseaudio.sh \
-#     /deps/build_pulseaudio.sh
+# bind /var/cache/apt to tmpfs to speed up baresip build
+RUN --mount=type=tmpfs,target=/tmp --mount=type=tmpfs,target=/var/cache/apt \
+    --mount=type=bind,source=docker/build_baresip.sh,target=/deps/build_baresip.sh \
+    /deps/build_baresip.sh
 
 FROM wget AS s6-overlay
 ARG TARGETARCH
@@ -68,6 +68,7 @@ FROM scratch AS deps-rootfs
 
 #COPY --from=pulseaudio /usr/local/pulseaudio/ /usr/local/pulseaudio/
 #COPY --from=pulsegstimage /usr/local/gstreamer/ /usr/local/gstreamer/
+COPY --from=baresip /usr/local/baresip/ /usr/
 COPY --from=s6-overlay /rootfs/ /
 COPY docker/rootfs/ /
 

--- a/docker/build_baresip.sh
+++ b/docker/build_baresip.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+LIBRE_VERSION=2.12.0
+LIBREM_VERSION=2.12.0
+BARESIP_VERSION=2.12.0
+
+echo "deb-src http://ftp.de.debian.org/debian/ bookworm main contrib non-free non-free-firmware" > /etc/apt/sources.list.d/sources-src.list
+apt-get update
+
+# Install build dependencies for baresip
+apt-get -qq install -y \
+    wget \
+    build-essential \
+    pkgconf \
+    cmake
+
+apt-get -qq build-dep -y baresip
+    
+# Create a temporary directory for building libre, download the source code, extract it, and remove the archive
+mkdir /tmp/libre
+wget https://github.com/baresip/re/archive/refs/tags/v${LIBRE_VERSION}.tar.gz
+tar -zxf v${LIBRE_VERSION}.tar.gz -C /tmp/libre --strip-components=1
+rm v${LIBRE_VERSION}.tar.gz
+
+# Create a temporary directory for building librem, download the source code, extract it, and remove the archive
+mkdir /tmp/librem
+wget https://github.com/baresip/rem/archive/refs/tags/v${LIBREM_VERSION}.tar.gz
+tar -zxf v${LIBREM_VERSION}.tar.gz -C /tmp/librem --strip-components=1
+rm v${LIBREM_VERSION}.tar.gz
+
+# Create a temporary directory for building baresip, download the source code, extract it, and remove the archive
+mkdir /tmp/baresip
+wget https://github.com/baresip/baresip/archive/refs/tags/v${BARESIP_VERSION}.tar.gz
+tar -zxf v${BARESIP_VERSION}.tar.gz -C /tmp/baresip --strip-components=1
+rm v${BARESIP_VERSION}.tar.gz
+
+mkdir -p /usr/local/baresip
+
+# Build and install libre
+cd /tmp/libre
+cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr/
+cmake --build build -j
+cmake --install build --prefix dist && cp -a dist/* /usr/ && cp -a dist/* /usr/local/baresip/
+
+# Build and install librem
+cd /tmp/librem
+cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr/
+cmake --build build -j
+cmake --install build --prefix dist && cp -a dist/* /usr/ && cp -a dist/* /usr/local/baresip/
+
+# Build and install baresip
+cd /tmp/baresip
+cmake -B build -DSTATIC=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr/
+cmake --build build -j
+cmake --install build --prefix dist && cp -a dist/* /usr/ && cp -a dist/* /usr/local/baresip/

--- a/docker/install_deps.sh
+++ b/docker/install_deps.sh
@@ -47,14 +47,11 @@ fi
 apt-get -qq install --no-install-recommends --no-install-suggests -y \
     libltdl7 \
     libtdb1 \
-    baresip \
-    baresip-core \
-    baresip-gstreamer \
-    baresip-x11 \
     python3-gi \
     libsoup2.4-1 \
     pulseaudio \
     pulseaudio-utils \
+    libopus0 ca-certificates openssl libasound2 libmosquitto1 libspandsp2 libpulse0 pulseaudio libopenaptx0 libportaudio2 \
     gir1.2-gst-rtsp-server-1.0 \
     gir1.2-gstreamer-1.0 \
     gir1.2-gst-plugins-bad-1.0 \

--- a/docker/rootfs/etc/baresip/config
+++ b/docker/rootfs/etc/baresip/config
@@ -78,7 +78,8 @@ rtp_stats		no
 #------------------------------------------------------------------------------
 # Modules
 
-module_path		/usr/lib/baresip/modules
+# baresip is linked statically
+#module_path		/usr/lib/baresip/modules
 
 # UI Modules
 #module			stdio.so
@@ -175,7 +176,7 @@ module_app		menu.so
 #module_app		syslog.so
 #module_app		mqtt.so
 module_app		ctrl_tcp.so
-#module_app		ctrl_dbus.so # later versions of baresip support module ctrl_dbus.so
+module_app		ctrl_dbus.so
 #module_app		httpreq.so
 #module_app		multicast.so
 #module_app		netroam.so
@@ -252,7 +253,7 @@ video_selfview		window # {window,pip}
 #avcodec_hwaccel	vaapi
 
 # ctrl_dbus
-#ctrl_dbus_use	system		# system, session
+ctrl_dbus_use	system		# system, session
 
 # mqtt
 #mqtt_broker_host	sollentuna.example.com

--- a/docker/rootfs/etc/dbus-1/system-local.conf
+++ b/docker/rootfs/etc/dbus-1/system-local.conf
@@ -1,0 +1,9 @@
+<!DOCTYPE busconfig PUBLIC
+"-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+    <policy user="root">
+        <allow eavesdrop="true"/>
+        <allow eavesdrop="true" send_destination="*"/>
+    </policy>
+</busconfig>

--- a/docker/rootfs/etc/dbus-1/system.d/baresip-system.conf
+++ b/docker/rootfs/etc/dbus-1/system.d/baresip-system.conf
@@ -1,0 +1,10 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+
+<busconfig>
+
+  <policy user="root">
+    <allow own="com.github.Baresip"/>
+  </policy>
+
+</busconfig>


### PR DESCRIPTION
The old version 1.x does not seem to be maintained properly concerning new features, etc.
Move to version 2.0.12.

Also connect baresip control to the system dbus daemon which was started anyway to silence pulseaudio errors.
Maybe we could move away from ctrl_tcp to ctrl_dbus in the python scripts.

